### PR TITLE
Add support for 0.12

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ sut:
     - bitcoind-username-only
 
 bitcoind:
-  image: seegno/bitcoind:0.11
+  image: seegno/bitcoind:0.12
   command:
     -datadir=/var/lib/bitcoind
     -printtoconsole

--- a/src/parser.js
+++ b/src/parser.js
@@ -11,6 +11,10 @@ import RpcError from './errors/rpc-error';
  */
 
 function get(body, { headers = false, response } = {}) {
+  if (!body) {
+    throw new RpcError(response.statusCode, response.statusMessage);
+  }
+
   if (body.error !== null) {
     throw new RpcError(
       _.get(body, 'error.code', -32603),

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -122,8 +122,8 @@ describe('Client', () => {
       return new Client(_.defaults({ headers: true }, config.bitcoind)).getInfo()
         .then(([info, headers]) => {
           info.should.be.an.Object();
-          headers.should.have.property('server');
-          headers.server.should.startWith('bitcoin-json-rpc');
+
+          headers.should.have.keys('date', 'connection', 'content-length', 'content-type');
         });
     });
 
@@ -132,8 +132,8 @@ describe('Client', () => {
         should.not.exist(err);
 
         info.should.be.an.Object();
-        headers.should.have.property('server');
-        headers.server.should.startWith('bitcoin-json-rpc');
+
+        headers.should.have.keys('date', 'connection', 'content-length', 'content-type');
       });
     });
 
@@ -146,8 +146,7 @@ describe('Client', () => {
         .then(([addresses, headers]) => {
           addresses.should.have.length(batch.length);
 
-          headers.should.have.property('server');
-          headers.server.should.startWith('bitcoin-json-rpc');
+          headers.should.have.keys('date', 'connection', 'content-length', 'content-type');
         });
     });
 
@@ -161,8 +160,7 @@ describe('Client', () => {
 
         addresses.should.have.length(batch.length);
 
-        headers.should.have.property('server');
-        headers.server.should.startWith('bitcoin-json-rpc');
+        headers.should.have.keys('date', 'connection', 'content-length', 'content-type');
       });
     });
   });
@@ -375,7 +373,7 @@ describe('Client', () => {
       it('should return a transaction json-encoded by default', () => {
         return client.listUnspent()
           .then(([transaction]) => client.getTransactionByHash(transaction.txid))
-          .then((transaction) => transaction.should.have.keys('blockhash', 'blocktime', 'confirmations', 'locktime', 'time', 'txid', 'version', 'vin', 'vout'));
+          .then((transaction) => transaction.should.have.keys('blockhash', 'blocktime', 'confirmations', 'locktime', 'size', 'time', 'txid', 'version', 'vin', 'vout'));
       });
     });
 
@@ -393,7 +391,7 @@ describe('Client', () => {
       it('should return a block json-encoded by default', () => {
         return client.getBlockByHash('0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206', { extension: 'json' })
           .then((block) => {
-            block.should.have.keys('bits', 'chainwork', 'confirmations', 'difficulty', 'hash', 'height', 'merkleroot', 'nextblockhash', 'nonce', 'size', 'time', 'tx', 'version');
+            block.should.have.keys('bits', 'chainwork', 'confirmations', 'difficulty', 'hash', 'height', 'mediantime', 'merkleroot', 'nextblockhash', 'nonce', 'size', 'time', 'tx', 'version');
             block.tx.should.matchEach((value) => value.should.be.an.Object());
           });
       });
@@ -401,7 +399,7 @@ describe('Client', () => {
       it('should return a block summary json-encoded if `summary` is enabled', () => {
         return client.getBlockByHash('0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206', { extension: 'json', summary: true })
           .then((block) => {
-            block.should.have.keys('bits', 'chainwork', 'confirmations', 'difficulty', 'hash', 'height', 'merkleroot', 'nextblockhash', 'nonce', 'size', 'time', 'tx', 'version');
+            block.should.have.keys('bits', 'chainwork', 'confirmations', 'difficulty', 'hash', 'height', 'mediantime', 'merkleroot', 'nextblockhash', 'nonce', 'size', 'time', 'tx', 'version');
             block.tx.should.matchEach((value) => value.should.be.a.String());
           });
       });
@@ -473,14 +471,14 @@ describe('Client', () => {
     describe('getMemoryPoolContent()', () => {
       it('should return memory pool content json-encoded by default', () => {
         return new Client(config.bitcoind).getMemoryPoolContent()
-          .then((content) => content.should.equal('Not Found'));
+          .then((content) => content.should.eql({}));
       });
     });
 
     describe('getMemoryPoolInformation()', () => {
       it('should return memory pool information json-encoded by default', () => {
         return new Client(config.bitcoind).getMemoryPoolContent()
-          .then((information) => information.should.equal('Not Found'));
+          .then((information) => information.should.eql({}));
       });
     });
   });


### PR DESCRIPTION
Differences from 0.11:

- Username-only authentication is no longer possible without read access to the random cookie file generated by bitcoind when `-rpcpassword` is not set (see https://github.com/bitcoin/bitcoin/pull/6388/files). This is the output of bitcoin-cli when connecting without `-rpcpassword` and without access to the cookie file:

  ```
  error: Could not locate RPC credentials. No authentication cookie could be found, and no rpcpassword is set in the configuration file (/root/.bitcoin/bitcoin.conf)
  ```
  Technically, it is possible to send a request via Basic Authentication by reading the cookie file on the server and using the predefined username `__cookie__`, although that defeats the purpose of not having a password set in the first place.

  Support for sending requests with username-only will remain while 0.11 is maintained.

- Some HTTP errors, such as 401 Unauthorized no longer rely on a message on the body. Instead, a proper status code and message are set.

- HTTPS has been removed. Instead, stunnel or other similar techniques must be used instead. Support for sending HTTPS requests will remain while 0.11 is maintained. 

- The `server` response header is no longer available.

- The `mediantime` property was added to the `getBlockByHash()` call.

- The `size` property was added to the `getTransactionByHash()` call.

- The `getMemoryPoolContent()` and `getMemoryPoolInformation()` calls no longer return 404 when no information is available. Instead, they now return a proper empty object.