### PR TITLE
Minor process improvements

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,4 @@
-Changelog.md
+CHANGELOG.md
 coverage
 dist
 node_modules

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+dist -diff

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
+language: bash
+
 script:
   - docker-compose run --rm sut
 
 services:
   - docker
-
-sudo: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,18 @@
-FROM mhart/alpine-node:5
+FROM mhart/alpine-node:4
 
-RUN apk add --update make gcc g++ python git && rm -rf /var/cache/apk/*
+RUN adduser -S node
 
-RUN adduser -S bitcoin
+WORKDIR /home/node/app
 
-WORKDIR /home/bitcoin/app
-
-COPY package.json /home/bitcoin/app/
+COPY package.json /home/node/app/
 
 RUN npm install --ignore-scripts
 
-COPY . /home/bitcoin/app/
+COPY . /home/node/app/
 
-RUN chown -R bitcoin /home/bitcoin
+RUN chown -R node /home/node
 
-USER bitcoin
-
-RUN npm rebuild
+USER node
 
 RUN npm run transpile
 

--- a/README.md
+++ b/README.md
@@ -283,8 +283,19 @@ const client = new Client({
 
 ## Tests
 
+Currently the test suite is tailored for Docker (including `docker-compose`) due to the multitude of different `bitcoind` configurations that are required in order to get the test suite passing.
+
+To test using a local installation of `node.js` but with dependencies (e.g. `bitcoind`) running inside Docker:
+
 ```sh
+npm run dependencies
 npm test
+```
+
+To test using Docker exclusively (similarly to what is done in Travis CI):
+
+```sh
+npm run testdocker
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ These configuration values may also be set on the `bitcoin.conf` file of your pl
 ### getTransactionByHash()
 Given a transaction hash, returns a transaction in binary, hex-encoded binary, or JSON formats.
 
-##### Arguments
+#### Arguments
 1. `hash` _(string)_: the transaction hash.
 2. `[summary=false]` _(boolean)_: whether to return just the transaction hash, thus saving memory.
 3. `[extension=json]` _(string)_: return in binary (`bin`), hex-encoded binary (`hex`), or JSON format.
@@ -197,14 +197,14 @@ Given a transaction hash, returns a transaction in binary, hex-encoded binary, o
 ### getBlockByHash()
 Given a block hash, returns a block, in binary, hex-encoded binary or JSON formats.
 
-##### Arguments
+#### Arguments
 1. `hash` _(string)_: the block hash.
 2. `[extension=json]` _(string)_: return in binary (`bin`), hex-encoded binary (`hex`), or JSON format.
 
 ### getBlockHeadersByHash()
 Given a block hash, returns amount of block headers in upward direction.
 
-##### Arguments
+#### Arguments
 1. `hash` _(string)_: the block hash.
 2. `count` _(number)_: the number of blocks to count in upward direction.
 3. `[extension=json]` _(string)_: return in binary (`bin`), hex-encoded binary (`hex`), or JSON format.
@@ -215,7 +215,7 @@ Returns various state info regarding block chain processing.
 ### getUnspentTransactionOutputs()
 Query unspent transaction outputs (UTXO) for a given set of outpoints. See [BIP64](https://github.com/bitcoin/bips/blob/master/bip-0064.mediawiki) for input and output serialisation.
 
-##### Arguments
+#### Arguments
 1. `outpoints` _(array\<Object\>|Object)_: the outpoint to query in the format `{ id: "<txid>", index: "<index>" }`.
 2. `[extension=json]` _(string)_: return in binary (`bin`), hex-encoded binary (`hex`), or JSON format.
 

--- a/README.md
+++ b/README.md
@@ -282,7 +282,6 @@ const client = new Client({
 ```
 
 ## Tests
-
 Currently the test suite is tailored for Docker (including `docker-compose`) due to the multitude of different `bitcoind` configurations that are required in order to get the test suite passing.
 
 To test using a local installation of `node.js` but with dependencies (e.g. `bitcoind`) running inside Docker:
@@ -296,6 +295,12 @@ To test using Docker exclusively (similarly to what is done in Travis CI):
 
 ```sh
 npm run testdocker
+```
+
+## Release
+
+```sh
+npm version [<newversion> | major | minor | patch] -m "Release %s"
 ```
 
 ## License

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,6 @@ sut:
 bitcoind:
   image: seegno/bitcoind:0.12
   command:
-    -datadir=/var/lib/bitcoind
     -printtoconsole
     -regtest=1
     -rest
@@ -26,7 +25,6 @@ bitcoind:
 bitcoind-ssl:
   image: seegno/bitcoind:0.11
   command:
-    -datadir=/var/lib/bitcoind
     -printtoconsole
     -regtest=1
     -rest
@@ -47,7 +45,6 @@ bitcoind-ssl:
 bitcoind-username-only:
   image: seegno/bitcoind:0.11
   command:
-    -datadir=/var/lib/bitcoind
     -printtoconsole
     -regtest=1
     -rest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,7 @@ bitcoind-ssl:
     -rest
     -rpcallowip=10.211.0.0/16
     -rpcallowip=172.17.0.0/16
+    -rpcallowip=192.168.0.0/16
     -rpcpassword=bar
     -rpcssl
     -rpcsslcertificatechainfile=/etc/ssl/bitcoind/cert.pem

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "prepublish": "npm run transpile",
     "testdocker": "docker-compose run --rm sut",
     "test": "mocha $npm_package_options_mocha",
-    "transpile": "rm -rf dist/* && babel src --out-dir dist"
+    "transpile": "rm -rf dist/* && babel src --out-dir dist",
+    "version": "npm run changelog -- --future-release=$npm_package_version && sed -i '' -e :a -e '$d;N;2,3ba' -e 'P;D' CHANGELOG.md && npm run transpile && git add -A CHANGELOG.md dist"
   },
   "dependencies": {
     "bluebird": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -29,10 +29,11 @@
   "scripts": {
     "changelog": "github_changelog_generator --no-issues --header-label='# Changelog'",
     "cover": "babel-node node_modules/.bin/isparta cover --report html _mocha -- $npm_package_options_mocha",
+    "dependencies": "docker-compose up -d bitcoind bitcoind-ssl bitcoind-username-only",
     "lint": "eslint src test && jscs src test",
     "prepublish": "npm run transpile",
     "testdocker": "docker-compose run --rm sut",
-    "test": "NODE_ENV=test mocha $npm_package_options_mocha",
+    "test": "mocha $npm_package_options_mocha",
     "transpile": "rm -rf dist/* && babel src --out-dir dist"
   },
   "dependencies": {


### PR DESCRIPTION
- Add automated releases support
- Remove unnecessary datadir command configuration
- Add local allowip to `bitcoind-ssl` service
- Fix incorrect title header on arguments
- Document how to run tests using docker
- Test using node 4 as that is the baseline
- Use bash environment on Travis CI without sudo
- Fix .dockerignore CHANGELOG.md filename
- Remove dist/ from git diff