### PR TITLE
Pin docker image to 0.13.0 to avoid failing tests on newer versions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ sut:
     - bitcoind-username-only
 
 bitcoind:
-  image: seegno/bitcoind:0.13-alpine
+  image: seegno/bitcoind:0.13.0-alpine
   command:
     -printtoconsole
     -regtest=1


### PR DESCRIPTION
Tests are currently failing due to changes from `bitcoind` version 0.13.0 to version 0.13.2.

This PR fixes the version of the `bitcoind` container to **0.13.0**.