### PR TITLE
Fix mempool naming inconsistency in getRawMempool method name

### DIFF
--- a/src/methods.js
+++ b/src/methods.js
@@ -72,7 +72,7 @@ export default {
   getNewAddress: { version: '>=0.1.0' },
   getPeerInfo: { version: '>=0.7.0' },
   getRawChangeAddress: { version: '>=0.9.0' },
-  getRawMemPool: { version: '>=0.7.0' },
+  getRawMempool: { version: '>=0.7.0' },
   getRawTransaction: { version: '>=0.7.0' },
   getReceivedByAccount: { version: '>=0.1.0' },
   getReceivedByAddress: { version: '>=0.1.0' },


### PR DESCRIPTION
@johnbailon I think the outlier here was `MemPool`. IMHO, it would either be `*MemoryPool` or `Mempool` as I see the shorter one as a single word. Thanks for pointing this inconsistency out!

Closes https://github.com/seegno/bitcoin-core/pull/20.