### PR TITLE
Add support for bitcoin 0.13.2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ sut:
     - bitcoind-username-only
 
 bitcoind:
-  image: seegno/bitcoind:0.13.0-alpine
+  image: seegno/bitcoind:0.13.2-alpine
   command:
     -printtoconsole
     -regtest=1

--- a/src/methods.js
+++ b/src/methods.js
@@ -19,7 +19,7 @@ export default {
   clearBanned: { version: '>=0.12.0' },
   createMultiSig: { version: '>=0.1.0' },
   createRawTransaction: { version: '>=0.7.0' },
-  createWitnessAddress: { version: '>=0.13.0' },
+  createWitnessAddress: { version: '=0.13.0' },
   decodeRawTransaction: { version: '>=0.7.0' },
   decodeScript: { version: '>=0.9.0' },
   disconnectNode: { version: '>=0.12.0' },

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -399,7 +399,7 @@ describe('Client', () => {
         const [transaction] = await client.listUnspent();
         const hex = await client.getTransactionByHash(transaction.txid, { extension: 'hex' });
 
-        hex.should.endWith('ac00000000\n');
+        hex.should.endWith('cf900000000\n');
       });
 
       it('should return a transaction json-encoded by default', async () => {


### PR DESCRIPTION
Fixes #23 .

This PR resumes in the following changes:
- Bump `bitcoind` docker image to 0.13.2
- Fix version of method `createWitnessAddress` to `0.13.0`
- Change tests to support new transaction hex
